### PR TITLE
[chore] introduce tag-based auto release build CI

### DIFF
--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -1,0 +1,91 @@
+name: Android Build and Release on Tag
+
+on:
+  create:
+
+jobs:
+  build-and-release:
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+
+      - uses: actions/checkout@v4
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Gradle build
+        run: ./gradlew clean bundleRelease assembleRelease --no-daemon
+        env:
+          BITRISE: 'true'
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+          BITRISEIO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_ALIAS }}
+          BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+          BITRISEIO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Extract Version Number
+        run: echo "version=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_ENV
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-build-artifacts
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ env.version }}
+          draft: false
+          prerelease: false
+          body: "Description of the release for version ${{ env.version }}"
+          commitish: ${{ github.sha }}
+
+      - name: Find APK file
+        run: |
+          apk_path=$(find ./app/build/outputs/apk/release -name "giphy-*.apk" | head -n 1)
+          echo "apk_path=$apk_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset APK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.apk_path }}
+          asset_name: giphy-${{ env.version }}.apk
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Find AAB file
+        run: |
+          aab_path=$(find ./app/build/outputs/bundle/release -name "giphy-*.aab" | head -n 1)
+          echo "aab_path=$aab_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset AAB
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.aab_path }}
+          asset_name: giphy-${{ env.version }}.aab
+          asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -31,6 +31,7 @@ jobs:
         run: ./gradlew clean bundleRelease assembleRelease --no-daemon
         env:
           BITRISE: 'true'
+          GIPHYAPIKEY: ${{ secrets.GIPHYAPIKEY }}
           KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
           BITRISEIO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_ALIAS }}
           BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -76,24 +76,39 @@ more production-ready.
 * Added test cases - currently there are 27 unit tests and 7 instrumented tests
 
 ## To-do lists:
-Planned enhancements are now [logged as issues](https://github.com/ryanw-mobile/giphy-trending/issues?q=is%3Aopen+is%3Aissue+label%3Arefactor%2Cfeature%2Cfix%2Ctest).
+
+Planned enhancements are
+now [logged as issues](https://github.com/ryanw-mobile/giphy-trending/issues?q=is%3Aopen+is%3Aissue+label%3Arefactor%2Cfeature%2Cfix%2Ctest).
 
 ## Requirements
 
-* Android Studio Iguana | 2023.2.1 Canary 18
+* Android Studio Iguana | 2023.2.1
 * Android device or simulator running Android 9+ (API 28)
 
-## Setting up the keystore
+## Binaries download
 
-* Android keystore is not being stored in this repository. You need your own keystore to generate
+If you want to try out the app without building it, check out
+the [Releases section](https://github.com/ryanw-mobile/giphy-trending/releases) where you can find
+the APK and App Bundles for each major version. A working Giphy API key was applied when building
+the app, therefore you can test it by just installing it.
+
+## Building the App
+
+* To build the app by yourself, you need your own [Giphy API Key](https://developers.giphy.com/)
+*
+
+### Setting up the keystore
+
+Release builds will be signed if either the keystore file or environment variables are set.
+Otherwise, the app will be built unsigned and without the Giphy API key installed, which will not
+pull any data from the endpoint.
+
+### Local
+
+* Android Keystore is not being stored in this repository. You need your own Keystore to generate
   the apk / App Bundle
 
-* You also need to have your own [Giphy API Key](https://developers.giphy.com/)
-
-* To ensure sensitive data are not being pushed to Git by accident, the keystore and its passwords
-  are kept one level up of the project folder, so they are not managed by Git.
-
-* If your project folder is at `/app/giphy-trending/`, the keystore file and `keystore.properties`
+* If your project folder is at `/app/giphy-trending/`, the Keystore file and `keystore.properties`
   should be placed at `/app/`
 
 * The format of `keystore.properties` is:
@@ -105,7 +120,19 @@ Planned enhancements are now [logged as issues](https://github.com/ryanw-mobile/
      giphyApiKey="<your API Key here>"
   ```
 
-## Building the App
+### CI environment
+
+* This project has been configured to build automatically on CI.
+
+* The following environment variables have been set to provide the keystore:
+  ```
+     BITRISE = true
+     HOME = <the home directory of the bitrise environment>
+     BITRISEIO_ANDROID_KEYSTORE_PASSWORD = <your keystore password>
+     BITRISEIO_ANDROID_KEYSTORE_ALIAS = <your keystore alias>
+     BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD = <your keystore private key password>
+     GIPHYAPIKEY= <your API Key>
+  ```
 
 ### Build and install on the connected device
 
@@ -124,14 +151,13 @@ After August 2021, all new apps and games will be required to publish with the A
 format.
 
    ```
-   ./gradlew clean && ./gradlew bundleRelease
+   ./gradlew clean bundleRelease
    ```
 
 ### Build and sign an apk for distribution
 
    ```
-   ./gradlew clean && ./gradlew assembleRelease
+   ./gradlew clean assembleRelease
    ```
 
 * The generated apk(s) will be stored under `app/build/outputs/apk/`
-* Other usages can be listed using `./gradelew tasks`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
         applicationId = "uk.ryanwong.giphytrending"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 6
-        versionName = "1.4.0"
+        versionCode = 7
+        versionName = "1.4.1"
 
         resourceConfigurations += setOf("en")
 


### PR DESCRIPTION
Introduce the auto release build template, plus to make the app build even when absence of keystore.