### PR TITLE
Fix retrofit dataclass minified bug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,8 +59,8 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         buildToolsVersion = libs.versions.buildToolsVersion.get()
-        versionCode = 8
-        versionName = "2.0.0"
+        versionCode = libs.versions.versionCode.get().toInt()
+        versionName = libs.versions.versionName.get()
 
         resourceConfigurations += setOf("en")
 

--- a/app/src/main/java/com/rwmobi/giphytrending/data/source/network/model/TrendingNetworkResponse.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/data/source/network/model/TrendingNetworkResponse.kt
@@ -5,6 +5,7 @@
 
 package com.rwmobi.giphytrending.data.source.network.model
 
+import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import java.util.Date
 
@@ -16,6 +17,7 @@ import java.util.Date
  * Otherwise in a real project once we know what's required, we don't have to keep so much,
  * as they will be thrown away at the time we convert it to domain model anyway.
  */
+@Keep
 data class TrendingNetworkResponse(
     @Json(name = "data")
     val trendingData: List<TrendingData>,
@@ -23,6 +25,7 @@ data class TrendingNetworkResponse(
     val pagination: Pagination,
 )
 
+@Keep
 data class TrendingData(
     val analytics_response_payload: String,
     val bitly_gif_url: String,
@@ -45,24 +48,28 @@ data class TrendingData(
     val username: String,
 )
 
+@Keep
 data class Meta(
     val msg: String,
     val response_id: String,
     val status: Int,
 )
 
+@Keep
 data class Pagination(
     val count: Int,
     val offset: Int,
     val total_count: Int,
 )
 
+@Keep
 data class Images(
     val fixed_height: FixedHeight,
     val fixed_width: FixedWidth,
     val original: Original,
 )
 
+@Keep
 data class FixedHeight(
     val height: String,
     val mp4: String? = null,
@@ -74,6 +81,7 @@ data class FixedHeight(
     val width: String,
 )
 
+@Keep
 data class FixedWidth(
     val height: String,
     val mp4: String? = null,
@@ -85,6 +93,7 @@ data class FixedWidth(
     val width: String,
 )
 
+@Keep
 data class Original(
     val frames: String,
     val hash: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 # App configurations, not dependencies
+versionCode = "9"
+versionName = "2.0.1"
 minSdk = "28"
 targetSdk = "34"
 compileSdk = "34"


### PR DESCRIPTION
We lost the Proguard settings while migrating to Compose. But instead of reintroducing them, we can use `@Keep` to prevent the data class from being obfuscated. 
