### PR TITLE
(#142) Implement image download button

### DIFF
--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
@@ -17,9 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -134,33 +131,27 @@ fun GiphyItem(
             Spacer(modifier = Modifier.weight(1.0f))
 
             if (giphyImageItem.imageUrl.isNotEmpty()) {
-                IconButton(onClick = { onClickToDownload(giphyImageItem.imageUrl) }) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.baseline_file_download_24),
-                        contentDescription = stringResource(R.string.content_description_download_image),
-                        tint = LocalContentColor.current.copy(alpha = 0.68f),
-                    )
-                }
+                IconButtonWithToolTip(
+                    tooltipText = stringResource(R.string.content_description_download_image),
+                    painter = painterResource(id = R.drawable.baseline_file_download_24),
+                    onClick = { onClickToDownload(giphyImageItem.imageUrl) },
+                )
             }
 
             if (giphyImageItem.webUrl.isNotEmpty()) {
-                IconButton(onClick = { onClickToOpen(giphyImageItem.webUrl) }) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_baseline_open_in_browser_24),
-                        contentDescription = stringResource(R.string.content_description_open_in_browser),
-                        tint = LocalContentColor.current.copy(alpha = 0.68f),
-                    )
-                }
+                IconButtonWithToolTip(
+                    tooltipText = stringResource(R.string.content_description_open_in_browser),
+                    painter = painterResource(id = R.drawable.ic_baseline_open_in_browser_24),
+                    onClick = { onClickToOpen(giphyImageItem.webUrl) },
+                )
             }
 
             if (giphyImageItem.imageUrl.isNotEmpty()) {
-                IconButton(onClick = { onClickToShare(giphyImageItem.imageUrl) }) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
-                        contentDescription = stringResource(R.string.content_description_copy_image_link),
-                        tint = LocalContentColor.current.copy(alpha = 0.68f),
-                    )
-                }
+                IconButtonWithToolTip(
+                    tooltipText = stringResource(R.string.content_description_copy_image_link),
+                    painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
+                    onClick = { onClickToShare(giphyImageItem.imageUrl) },
+                )
             }
         }
     }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
@@ -53,6 +53,7 @@ fun GiphyItem(
     modifier: Modifier = Modifier,
     giphyImageItem: GiphyImageItem,
     imageLoader: ImageLoader,
+    onClickToDownload: (String) -> Unit,
     onClickToOpen: (String) -> Unit,
     onClickToShare: (String) -> Unit,
 ) {
@@ -133,6 +134,16 @@ fun GiphyItem(
             Spacer(modifier = Modifier.weight(1.0f))
 
             if (giphyImageItem.webUrl.isNotEmpty()) {
+                IconButton(onClick = { onClickToDownload(giphyImageItem.imageUrl) }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.baseline_file_download_24),
+                        contentDescription = stringResource(R.string.content_description_download_image),
+                        tint = LocalContentColor.current.copy(alpha = 0.68f),
+                    )
+                }
+            }
+
+            if (giphyImageItem.webUrl.isNotEmpty()) {
                 IconButton(onClick = { onClickToOpen(giphyImageItem.webUrl) }) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_baseline_open_in_browser_24),
@@ -167,6 +178,7 @@ private fun GiphyItemPreview(
                 modifier = Modifier.fillMaxWidth(),
                 giphyImageItem = giphyImageItem,
                 imageLoader = ImageLoader(LocalContext.current),
+                onClickToDownload = {},
                 onClickToShare = {},
                 onClickToOpen = {},
             )

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
@@ -53,9 +53,9 @@ fun GiphyItem(
     modifier: Modifier = Modifier,
     giphyImageItem: GiphyImageItem,
     imageLoader: ImageLoader,
-    onClickToDownload: (String) -> Unit,
-    onClickToOpen: (String) -> Unit,
-    onClickToShare: (String) -> Unit,
+    onClickToDownload: (imageUrl: String) -> Unit,
+    onClickToOpen: (url: String) -> Unit,
+    onClickToShare: (url: String) -> Unit,
 ) {
     val dimension = LocalConfiguration.current.getDimension()
     Column(
@@ -133,7 +133,7 @@ fun GiphyItem(
 
             Spacer(modifier = Modifier.weight(1.0f))
 
-            if (giphyImageItem.webUrl.isNotEmpty()) {
+            if (giphyImageItem.imageUrl.isNotEmpty()) {
                 IconButton(onClick = { onClickToDownload(giphyImageItem.imageUrl) }) {
                     Icon(
                         painter = painterResource(id = R.drawable.baseline_file_download_24),

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/IconButtonWithToolTip.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/IconButtonWithToolTip.kt
@@ -1,0 +1,42 @@
+package com.rwmobi.giphytrending.ui.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IconButtonWithToolTip(
+    modifier: Modifier = Modifier,
+    tooltipText: String,
+    painter: Painter,
+    onClick: () -> Unit,
+) {
+    TooltipBox(
+        modifier = modifier,
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        tooltip = {
+            PlainTooltip {
+                Text(tooltipText)
+            }
+        },
+        state = rememberTooltipState(),
+    ) {
+        IconButton(onClick = onClick) {
+            Icon(
+                painter = painter,
+                contentDescription = tooltipText,
+                tint = LocalContentColor.current.copy(alpha = 0.68f),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/utils/KotlinExtensions.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/utils/KotlinExtensions.kt
@@ -1,11 +1,36 @@
 package com.rwmobi.giphytrending.ui.utils
 
+import android.app.DownloadManager
 import android.content.Context
 import android.content.Intent
+import android.os.Environment
 import androidx.core.net.toUri
+import com.rwmobi.giphytrending.R
+import timber.log.Timber
 
-internal fun Context.startBrowserActivity(src: String) {
-    val uri = src.toUri().buildUpon().scheme("https").build()
+internal fun Context.startBrowserActivity(url: String) {
+    val uri = url.toUri().buildUpon().scheme("https").build()
     val intent = Intent(Intent.ACTION_VIEW).setData(uri)
     startActivity(intent)
+}
+
+internal fun Context.downloadImageUsingMediaStore(imageUrl: String): Boolean {
+    return try {
+        val identifier = imageUrl.substringAfterLast("/media/").substringBeforeLast('/')
+        val fileName = "giphy-$identifier.gif"
+        val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+
+        val request = DownloadManager.Request(imageUrl.toUri().buildUpon().scheme("https").build())
+            .setTitle(fileName)
+            .setDescription(getString(R.string.downloading_image))
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setAllowedOverMetered(true)
+            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+
+        downloadManager.enqueue(request)
+        true // Return true indicating the download request was successfully enqueued.
+    } catch (ex: Exception) {
+        Timber.tag("DownloadManager").e(ex)
+        false
+    }
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/utils/KotlinExtensions.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/utils/KotlinExtensions.kt
@@ -1,0 +1,11 @@
+package com.rwmobi.giphytrending.ui.utils
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+
+internal fun Context.startBrowserActivity(src: String) {
+    val uri = src.toUri().buildUpon().scheme("https").build()
+    val intent = Intent(Intent.ACTION_VIEW).setData(uri)
+    startActivity(intent)
+}

--- a/app/src/main/res/drawable/baseline_file_download_24.xml
+++ b/app/src/main/res/drawable/baseline_file_download_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="content_description_open_in_browser">Open in browser</string>
     <string name="content_description_copy_image_link">Copy image link</string>
     <string name="content_description_download_image">Download image</string>
+    <string name="download">Download</string>
+    <string name="downloading_image">Downloading image...</string>
+    <string name="failed_to_download_file">Failed to download file.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="content_description_trending_list">Trending List</string>
     <string name="content_description_open_in_browser">Open in browser</string>
     <string name="content_description_copy_image_link">Copy image link</string>
+    <string name="content_description_download_image">Download image</string>
 </resources>


### PR DESCRIPTION
Added a new button so it downloads the gif to the shared download folder using DownloadManager.
No extra permission is needed, and do not use any scoped storage after careful consideration.

I also updated the button to show a little tooltip box when long-tapping on it.

