### PR TITLE
(#177) (#178) search results retention and reset scroll position

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,22 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3

--- a/app/src/main/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImpl.kt
@@ -34,7 +34,7 @@ class SearchRepositoryImpl @Inject constructor(
     @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : SearchRepository {
     private var lastSuccessfulSearchKeyword: String? = null
-    private var lastSuccessfulSearchResults: Result<List<GiphyImageItem>>? = null
+    private var lastSuccessfulSearchResults: List<GiphyImageItem>? = null
 
     override suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>> {
         if (giphyApiKey.isBlank()) {
@@ -58,10 +58,9 @@ class SearchRepositoryImpl @Inject constructor(
                     rating = rating.apiValue,
                 )
 
-                Result.success(value = result.trendingData.asTrendingEntity().asGiphyImageItem()).also {
-                    lastSuccessfulSearchKeyword = keyword
-                    lastSuccessfulSearchResults = it
-                }
+                lastSuccessfulSearchKeyword = keyword
+                lastSuccessfulSearchResults = result.trendingData.asTrendingEntity().asGiphyImageItem()
+                Result.success(value = lastSuccessfulSearchResults ?: emptyList())
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (ex: Exception) {
@@ -72,5 +71,5 @@ class SearchRepositoryImpl @Inject constructor(
     }
 
     override fun getLastSuccessfulSearchKeyword(): String? = lastSuccessfulSearchKeyword
-    override fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>? = lastSuccessfulSearchResults
+    override fun getLastSuccessfulSearchResults(): List<GiphyImageItem>? = lastSuccessfulSearchResults
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImpl.kt
@@ -20,11 +20,22 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 
+/**
+ * While the data layer, including data sources, is responsible for managing the actual storage and retrieval of data,
+ * the repository serves as a boundary between the data layer and the rest of the application.
+ * Storing data in variables within the repository can be seen as a pragmatic approach to caching within the context
+ * of Clean Architecture, providing a balance between simplicity, maintainability, and flexibility.
+ * -- ChatGPT
+ */
+
 class SearchRepositoryImpl @Inject constructor(
     private val networkDataSource: NetworkDataSource,
     @GiphyApiKey private val giphyApiKey: String,
     @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : SearchRepository {
+    private var lastSuccessfulSearchKeyword: String? = null
+    private var lastSuccessfulSearchResults: Result<List<GiphyImageItem>>? = null
+
     override suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>> {
         if (giphyApiKey.isBlank()) {
             @Suppress("UNREACHABLE_CODE")
@@ -36,7 +47,7 @@ class SearchRepositoryImpl @Inject constructor(
             return Result.success(emptyList())
         }
 
-        // Search changes frequently, we do not cache results
+        // Search changes frequently, we only cache results in memory
         return withContext(dispatcher) {
             try {
                 val result = networkDataSource.getSearch(
@@ -47,7 +58,10 @@ class SearchRepositoryImpl @Inject constructor(
                     rating = rating.apiValue,
                 )
 
-                Result.success(value = result.trendingData.asTrendingEntity().asGiphyImageItem())
+                Result.success(value = result.trendingData.asTrendingEntity().asGiphyImageItem()).also {
+                    lastSuccessfulSearchKeyword = keyword
+                    lastSuccessfulSearchResults = it
+                }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (ex: Exception) {
@@ -56,4 +70,7 @@ class SearchRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override fun getLastSuccessfulSearchKeyword(): String? = lastSuccessfulSearchKeyword
+    override fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>? = lastSuccessfulSearchResults
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/di/NetworkDataSourceModule.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/di/NetworkDataSourceModule.kt
@@ -11,13 +11,13 @@ import com.rwmobi.giphytrending.data.source.network.interfaces.NetworkDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
-import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 object NetworkDataSourceModule {
-    @ViewModelScoped
+    @Singleton
     @Provides
     fun provideNetworkDataSource(
         giphyApiService: GiphyApi,

--- a/app/src/main/java/com/rwmobi/giphytrending/di/SearchRepositoryModule.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/di/SearchRepositoryModule.kt
@@ -11,14 +11,14 @@ import com.rwmobi.giphytrending.domain.repository.SearchRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
-import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 object SearchRepositoryModule {
-    @ViewModelScoped
+    @Singleton
     @Provides
     fun provideSearchRepository(
         networkDataSource: NetworkDataSource,

--- a/app/src/main/java/com/rwmobi/giphytrending/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/domain/repository/SearchRepository.kt
@@ -11,4 +11,6 @@ import com.rwmobi.giphytrending.domain.model.Rating
 interface SearchRepository {
 
     suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>>
+    fun getLastSuccessfulSearchKeyword(): String?
+    fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>?
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/domain/repository/SearchRepository.kt
@@ -12,5 +12,5 @@ interface SearchRepository {
 
     suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>>
     fun getLastSuccessfulSearchKeyword(): String?
-    fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>?
+    fun getLastSuccessfulSearchResults(): List<GiphyImageItem>?
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
@@ -21,13 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.net.toUri
@@ -64,16 +62,13 @@ fun SearchScreen(
     val coroutineScope = rememberCoroutineScope()
     val clipboardHistory = remember { mutableStateListOf<String>() }
     val focusManager: FocusManager = LocalFocusManager.current
-    val nestedScrollConnection = rememberNestedScrollInteropConnection()
 
     Box(
-        modifier = modifier
-            .nestedScroll(connection = nestedScrollConnection)
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onTap = { coroutineScope.launch { focusManager.clearFocus() } },
-                )
-            },
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures(
+                onTap = { coroutineScope.launch { focusManager.clearFocus() } },
+            )
+        },
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -120,8 +115,9 @@ fun SearchScreen(
         }
 
         DisposableEffect(true) {
+            uiEvent.onFetchLastSuccessfulSearch()
+
             onDispose {
-                uiEvent.onClearKeyword
                 coroutineScope.launch {
                     focusManager.clearFocus()
                 }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchUIEvent.kt
@@ -6,6 +6,7 @@
 package com.rwmobi.giphytrending.ui.destinations.search
 
 data class SearchUIEvent(
+    val onFetchLastSuccessfulSearch: () -> Unit,
     val onUpdateKeyword: (keyword: String) -> Unit,
     val onClearKeyword: () -> Unit,
     val onSearch: () -> Unit,

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
@@ -103,9 +103,13 @@ fun AppNavHost(
                 imageLoader = viewModel.getImageLoader(),
                 uiState = uiState,
                 uiEvent = SearchUIEvent(
+                    onFetchLastSuccessfulSearch = { viewModel.fetchLastSuccessfulSearch() },
                     onClearKeyword = { viewModel.clearKeyword() },
                     onUpdateKeyword = { viewModel.updateKeyword(it) },
-                    onSearch = { viewModel.search() },
+                    onSearch = {
+                        resetScrollBehavior()
+                        viewModel.search()
+                    },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Search) },
                     onShowSnackbar = onShowSnackbar,

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
@@ -77,7 +77,6 @@ fun AppNavHost(
                 ),
             )
 
-            // Reset the scroll behavior when this composable enters
             LaunchedEffect(Unit) {
                 resetScrollBehavior()
             }
@@ -116,7 +115,6 @@ fun AppNavHost(
                 ),
             )
 
-            // Reset the scroll behavior when this composable enters
             LaunchedEffect(Unit) {
                 resetScrollBehavior()
             }
@@ -151,7 +149,6 @@ fun AppNavHost(
                 ),
             )
 
-            // Reset the scroll behavior when this composable enters
             LaunchedEffect(Unit) {
                 resetScrollBehavior()
             }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
@@ -95,6 +95,13 @@ class SearchViewModel @Inject constructor(
         val rating = userPreferences.rating
 
         if (apiMaxEntries != null && rating != null) {
+            // This forces the scrolling to the top of the list
+            _uiState.update { currentUiState ->
+                currentUiState.copy(
+                    isLoading = true,
+                    giphyImageItems = emptyList(),
+                )
+            }
             startNewSearch(keyword = keyword, apiMaxEntries = apiMaxEntries, rating = rating)
         } else {
             updateUIForError("Preferences are not fully set.")

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
@@ -52,6 +52,22 @@ class SearchViewModel @Inject constructor(
         collectUserPreferences()
     }
 
+    fun fetchLastSuccessfulSearch() {
+        startLoading()
+        viewModelScope.launch(dispatcher) {
+            val lastSearchKeyword = searchRepository.getLastSuccessfulSearchKeyword()
+            val lastSearchResult = searchRepository.getLastSuccessfulSearchResults()
+
+            _uiState.update { currentUiState ->
+                currentUiState.copy(
+                    isLoading = false,
+                    keyword = lastSearchKeyword ?: "",
+                    giphyImageItems = lastSearchResult,
+                )
+            }
+        }
+    }
+
     fun updateKeyword(keyword: String?) {
         // caller is not allowed to feed us null value, which is reserved to the ViewModel
         this.keyword = keyword?.take(keywordMaxLength) ?: ""
@@ -138,15 +154,6 @@ class SearchViewModel @Inject constructor(
         _uiState.update { it.copy(isLoading = true) }
     }
 
-    private fun updateUIForError(message: String) {
-        _uiState.update {
-            addErrorMessage(
-                currentUiState = it,
-                message = message,
-            )
-        }
-    }
-
     private fun startNewSearch(keyword: String?, apiMaxEntries: Int, rating: Rating) {
         viewModelScope.launch(dispatcher) {
             val searchResult = searchRepository.search(keyword = keyword, limit = apiMaxEntries, rating = rating)
@@ -165,6 +172,15 @@ class SearchViewModel @Inject constructor(
                     Timber.tag("processTrendingList").v("Processed ${repositoryResult.getOrNull()?.count() ?: 0} entries")
                 }
             }
+        }
+    }
+
+    private fun updateUIForError(message: String) {
+        _uiState.update {
+            addErrorMessage(
+                currentUiState = it,
+                message = message,
+            )
         }
     }
 

--- a/app/src/test/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImplTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/data/repository/SearchRepositoryImplTest.kt
@@ -125,7 +125,7 @@ class SearchRepositoryImplTest {
         val lastSuccessfulSearchKeyword = searchRepository.getLastSuccessfulSearchKeyword()
         val lastSuccessfulSearchResults = searchRepository.getLastSuccessfulSearchResults()
         lastSuccessfulSearchKeyword shouldBe keyword
-        lastSuccessfulSearchResults?.getOrNull() shouldBe SampleSearchNetworkResponse.singleResponse.trendingData.asTrendingEntity().asGiphyImageItem()
+        lastSuccessfulSearchResults shouldBe SampleSearchNetworkResponse.singleResponse.trendingData.asTrendingEntity().asGiphyImageItem()
     }
 
     @Test
@@ -140,6 +140,6 @@ class SearchRepositoryImplTest {
         val lastSuccessfulSearchKeyword = searchRepository.getLastSuccessfulSearchKeyword()
         val lastSuccessfulSearchResults = searchRepository.getLastSuccessfulSearchResults()
         lastSuccessfulSearchKeyword shouldBe keyword
-        lastSuccessfulSearchResults?.getOrNull() shouldBe SampleSearchNetworkResponse.singleResponse.trendingData.asTrendingEntity().asGiphyImageItem()
+        lastSuccessfulSearchResults shouldBe SampleSearchNetworkResponse.singleResponse.trendingData.asTrendingEntity().asGiphyImageItem()
     }
 }

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
@@ -38,17 +38,45 @@ internal class SearchViewModelTest {
         )
     }
 
+    // fetchLastSuccessfulSearch
+    @Test
+    fun `fetchLastSuccessfulSearch should update UIState correctly if repository return something`() = runTest {
+        val lastSuccessfulSearchKeyword = "last serach keyword"
+        val lastSuccessfulSearchResult = SampleGiphyImageItemList.giphyImageItemList
+        fakeSearchRepository.setLastSuccessfulSearchKeywordForTest(lastSuccessfulSearchKeyword)
+        fakeSearchRepository.setLastSuccessfulSearchResultsForTest(lastSuccessfulSearchResult)
+
+        viewModel.fetchLastSuccessfulSearch()
+
+        with(viewModel.uiState.value) {
+            isLoading shouldBe false
+            keyword shouldBe lastSuccessfulSearchKeyword
+            giphyImageItems shouldContainExactlyInAnyOrder lastSuccessfulSearchResult
+        }
+    }
+
+    @Test
+    fun `fetchLastSuccessfulSearch should update UIState with default values if repository return null`() = runTest {
+        viewModel.fetchLastSuccessfulSearch()
+
+        with(viewModel.uiState.value) {
+            isLoading shouldBe false
+            keyword shouldBe ""
+            giphyImageItems shouldBe null
+        }
+    }
+
     @Test
     fun `updateKeyword should update keyword correctly`() = runTest {
         val keyword = "some search keyword"
         viewModel.updateKeyword(keyword)
-        assert(viewModel.uiState.value.keyword == keyword)
+        viewModel.uiState.value.keyword shouldBe keyword
     }
 
     @Test
     fun `updateKeyword should handle null input by clearing keyword`() = runTest {
         viewModel.updateKeyword(null)
-        assert(viewModel.uiState.value.keyword.isEmpty())
+        viewModel.uiState.value.keyword.isEmpty() shouldBe true
     }
 
     @Test
@@ -65,7 +93,7 @@ internal class SearchViewModelTest {
     fun `clearKeyword should reset keyword state`() = runTest {
         viewModel.updateKeyword("test")
         viewModel.clearKeyword()
-        assert(viewModel.uiState.value.keyword.isEmpty())
+        viewModel.uiState.value.keyword.isEmpty() shouldBe true
     }
 
     @Test

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
@@ -76,7 +76,7 @@ internal class SearchViewModelTest {
                 rating = Rating.G,
             ),
         )
-        fakeSearchRepository.searchResult = Result.success(SampleGiphyImageItemList.giphyImageItemList)
+        fakeSearchRepository.setSearchResultForTest(Result.success(SampleGiphyImageItemList.giphyImageItemList))
 
         viewModel.updateKeyword("test")
         viewModel.search()
@@ -112,7 +112,7 @@ internal class SearchViewModelTest {
                 rating = Rating.G,
             ),
         )
-        fakeSearchRepository.searchResult = Result.failure(RuntimeException(errorMessage))
+        fakeSearchRepository.setSearchResultForTest(Result.failure(RuntimeException(errorMessage)))
 
         viewModel.updateKeyword("test")
         viewModel.search()

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModelTest.kt
@@ -59,7 +59,7 @@ internal class TrendingViewModelTest {
                 rating = Rating.G,
             ),
         )
-        fakeTrendingRepository.trendingResult = Result.success(emptyList())
+        fakeTrendingRepository.setTrendingResultForTest(Result.success(emptyList()))
 
         setupViewModel()
 
@@ -76,7 +76,7 @@ internal class TrendingViewModelTest {
                 rating = Rating.G,
             ),
         )
-        fakeTrendingRepository.trendingResult = Result.failure(Exception(errorMessage))
+        fakeTrendingRepository.setTrendingResultForTest(Result.failure(Exception(errorMessage)))
 
         setupViewModel()
 
@@ -92,10 +92,10 @@ internal class TrendingViewModelTest {
                 rating = Rating.G,
             ),
         )
-        fakeTrendingRepository.trendingResult = Result.success(emptyList())
+        fakeTrendingRepository.setTrendingResultForTest(Result.success(emptyList()))
         setupViewModel()
 
-        fakeTrendingRepository.trendingResult = Result.success(SampleGiphyImageItemList.giphyImageItemList)
+        fakeTrendingRepository.setTrendingResultForTest(Result.success(SampleGiphyImageItemList.giphyImageItemList))
         viewModel.refresh()
 
         viewModel.uiState.value.giphyImageItems shouldBe SampleGiphyImageItemList.giphyImageItemList

--- a/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeSearchRepository.kt
+++ b/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeSearchRepository.kt
@@ -7,14 +7,14 @@ import com.rwmobi.giphytrending.domain.repository.SearchRepository
 class FakeSearchRepository : SearchRepository {
     private var searchResult: Result<List<GiphyImageItem>>? = null
     private var lastSuccessfulSearchKeyword: String? = null
-    private var lastSuccessfulSearchResults: Result<List<GiphyImageItem>>? = null
+    private var lastSuccessfulSearchResults: List<GiphyImageItem>? = null
 
     override suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>> {
         return searchResult ?: Result.success(emptyList())
     }
 
     override fun getLastSuccessfulSearchKeyword(): String? = lastSuccessfulSearchKeyword
-    override fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>? = lastSuccessfulSearchResults
+    override fun getLastSuccessfulSearchResults(): List<GiphyImageItem>? = lastSuccessfulSearchResults
 
     fun setSearchResultForTest(searchResult: Result<List<GiphyImageItem>>?) {
         this.searchResult = searchResult
@@ -24,7 +24,7 @@ class FakeSearchRepository : SearchRepository {
         this.lastSuccessfulSearchKeyword = lastSuccessfulSearchKeyword
     }
 
-    fun setLastSuccessfulSearchResultsForTest(lastSuccessfulSearchResults: Result<List<GiphyImageItem>>?) {
+    fun setLastSuccessfulSearchResultsForTest(lastSuccessfulSearchResults: List<GiphyImageItem>?) {
         this.lastSuccessfulSearchResults = lastSuccessfulSearchResults
     }
 }

--- a/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeSearchRepository.kt
+++ b/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeSearchRepository.kt
@@ -5,9 +5,26 @@ import com.rwmobi.giphytrending.domain.model.Rating
 import com.rwmobi.giphytrending.domain.repository.SearchRepository
 
 class FakeSearchRepository : SearchRepository {
-    var searchResult: Result<List<GiphyImageItem>>? = null
+    private var searchResult: Result<List<GiphyImageItem>>? = null
+    private var lastSuccessfulSearchKeyword: String? = null
+    private var lastSuccessfulSearchResults: Result<List<GiphyImageItem>>? = null
 
     override suspend fun search(keyword: String?, limit: Int, rating: Rating): Result<List<GiphyImageItem>> {
         return searchResult ?: Result.success(emptyList())
+    }
+
+    override fun getLastSuccessfulSearchKeyword(): String? = lastSuccessfulSearchKeyword
+    override fun getLastSuccessfulSearchResults(): Result<List<GiphyImageItem>>? = lastSuccessfulSearchResults
+
+    fun setSearchResultForTest(searchResult: Result<List<GiphyImageItem>>?) {
+        this.searchResult = searchResult
+    }
+
+    fun setLastSuccessfulSearchKeywordForTest(lastSuccessfulSearchKeyword: String?) {
+        this.lastSuccessfulSearchKeyword = lastSuccessfulSearchKeyword
+    }
+
+    fun setLastSuccessfulSearchResultsForTest(lastSuccessfulSearchResults: Result<List<GiphyImageItem>>?) {
+        this.lastSuccessfulSearchResults = lastSuccessfulSearchResults
     }
 }

--- a/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeTrendingRepository.kt
+++ b/app/src/testFixtures/java/com/rwmobi/giphytrending/data/repository/FakeTrendingRepository.kt
@@ -5,12 +5,17 @@ import com.rwmobi.giphytrending.domain.model.Rating
 import com.rwmobi.giphytrending.domain.repository.TrendingRepository
 
 class FakeTrendingRepository : TrendingRepository {
-    var trendingResult: Result<List<GiphyImageItem>>? = null
+    private var trendingResult: Result<List<GiphyImageItem>>? = null
+
     override suspend fun fetchCachedTrending(): Result<List<GiphyImageItem>> {
         return trendingResult ?: Result.success(emptyList())
     }
 
     override suspend fun reloadTrending(limit: Int, rating: Rating): Result<List<GiphyImageItem>> {
         return trendingResult ?: Result.success(emptyList())
+    }
+
+    fun setTrendingResultForTest(trendingResult: Result<List<GiphyImageItem>>?) {
+        this.trendingResult = trendingResult
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # App configurations, not dependencies
-versionCode = "13"
-versionName = "2.3.0"
+versionCode = "14"
+versionName = "2.3.1"
 minSdk = "28"
 targetSdk = "34"
 compileSdk = "34"


### PR DESCRIPTION
Last successful search keyword and results are now stored in memory in the repository, so it will survive in the current app session. That means switching between tabs will now have the search results retained.

When firing a new valid search (means the keyword isn't empty), the app will scroll back to the top and reset the app bar scrolling state.

some little unit test refactoring done in this ticket.

Experimental Gradle Dependency Submission Action is added.

This can be tagged for app release.

This ticket closes #177 
This ticket closes #178