### PR TITLE
(#190) show snackbar when downloading gif

### DIFF
--- a/app/src/androidTest/java/com/rwmobi/giphytrending/ui/MainActivityTestRobot.kt
+++ b/app/src/androidTest/java/com/rwmobi/giphytrending/ui/MainActivityTestRobot.kt
@@ -116,14 +116,14 @@ internal class MainActivityTestRobot(
         }
     }
 
-    fun checkErrorSnackbarIsDisplayedAndDismissed(exceptionMessage: String) {
+    fun checkSnackbarIsDisplayedAndDismissed(message: String) {
         try {
-            assertSnackbarIsDisplayed(message = exceptionMessage)
+            assertSnackbarIsDisplayed(message = message)
             tapOK()
-            assertSnackbarIsNotDisplayed(message = exceptionMessage)
+            assertSnackbarIsNotDisplayed(message = message)
         } catch (e: AssertionError) {
             composeTestRule.onRoot().printToLog("MainActivityTestRobotError")
-            throw AssertionError("Expected error snackbar behavior is not observed. ${e.message}", e)
+            throw AssertionError("Expected snackbar behavior is not observed. ${e.message}", e)
         }
     }
 

--- a/app/src/androidTest/java/com/rwmobi/giphytrending/ui/components/GiphyItemTestRobot.kt
+++ b/app/src/androidTest/java/com/rwmobi/giphytrending/ui/components/GiphyItemTestRobot.kt
@@ -46,15 +46,16 @@ internal class GiphyItemTestRobot(
     fun checkGiphyImageItemButtonsLongClickToolTipAreDisplayed() {
         try {
             with(composeTestRule) {
-                assertLongClickToolTipIsDisplayed(
-                    contentDescription = activity.getString(R.string.content_description_copy_image_link),
-                )
-                assertLongClickToolTipIsDisplayed(
-                    contentDescription = activity.getString(R.string.content_description_download_image),
-                )
-                assertLongClickToolTipIsDisplayed(
-                    contentDescription = activity.getString(R.string.content_description_open_in_browser),
-                )
+                listOf(
+                    R.string.content_description_copy_image_link,
+                    R.string.content_description_download_image,
+                    R.string.content_description_open_in_browser,
+                ).forEach {
+                    assertLongClickToolTipIsDisplayed(
+                        contentDescription = activity.getString(it),
+                    )
+                    waitForIdle()
+                }
             }
         } catch (e: AssertionError) {
             composeTestRule.onRoot().printToLog("GiphyItemTestRobotError")

--- a/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreenTest.kt
@@ -8,6 +8,7 @@ package com.rwmobi.giphytrending.ui.destinations.search
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rwmobi.giphytrending.MainActivity
+import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.data.repository.FakeUITestSearchRepository
 import com.rwmobi.giphytrending.data.repository.FakeUITestUserPreferencesRepository
 import com.rwmobi.giphytrending.domain.model.Rating
@@ -85,7 +86,7 @@ class SearchScreenTest {
                 val exceptionMessage = "Testing Exception"
                 fakeSearchRepository.setSearchResultForTest(Result.failure(IOException(exceptionMessage)))
                 checkCanPerformSearchWithKeyword("any test keywords")
-                checkErrorSnackbarIsDisplayedAndDismissed(exceptionMessage = "Error getting data: $exceptionMessage")
+                checkSnackbarIsDisplayedAndDismissed(message = "Error getting data: $exceptionMessage")
                 checkCanClearSearchKeyword()
             }
 
@@ -102,9 +103,7 @@ class SearchScreenTest {
                 }
 
                 // Second top should scroll back to the top
-                with(mainActivityTestRobot) {
-                    secondTapOnSearchTab()
-                }
+                mainActivityTestRobot.secondTapOnSearchTab()
                 checkGiphyItemIsDisplayed(gifObject = SampleGifObjectList.gifObjects.first())
             }
 
@@ -122,6 +121,7 @@ class SearchScreenTest {
                 checkGiphyImageItemButtonsLongClickToolTipAreDisplayed()
                 checkOpenInBrowserButton(url = lastGiphyItem.webUrl)
                 checkDownloadImageButton(imageUrl = lastGiphyItem.imageUrl)
+                mainActivityTestRobot.checkSnackbarIsDisplayedAndDismissed(message = composeTestRule.activity.getString(R.string.image_queued_for_download))
                 checkCopyImageLinkButton()
             }
 

--- a/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/settings/SettingsScreenTest.kt
@@ -74,7 +74,7 @@ class SettingsScreenTest {
             with(mainActivityTestRobot) {
                 val exceptionMessage = "Testing Exception"
                 fakeUserPreferencesRepository.emitError(IOException(exceptionMessage))
-                checkErrorSnackbarIsDisplayedAndDismissed(exceptionMessage = exceptionMessage)
+                checkSnackbarIsDisplayedAndDismissed(message = exceptionMessage)
             }
 
             // Currently not meaningful to test - until this screen becomes lengthy

--- a/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreenTest.kt
+++ b/app/src/androidTest/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreenTest.kt
@@ -8,6 +8,7 @@ package com.rwmobi.giphytrending.ui.destinations.trendinglist
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rwmobi.giphytrending.MainActivity
+import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.data.repository.FakeUITestTrendingRepository
 import com.rwmobi.giphytrending.data.repository.FakeUITestUserPreferencesRepository
 import com.rwmobi.giphytrending.domain.model.Rating
@@ -93,9 +94,7 @@ class TrendingListScreenTest {
                 }
 
                 // Second top should scroll back to the top
-                with(mainActivityTestRobot) {
-                    secondTapOnTrendingTab()
-                }
+                mainActivityTestRobot.secondTapOnTrendingTab()
                 checkGiphyItemIsDisplayed(gifObject = SampleGifObjectList.gifObjects.first())
             }
 
@@ -104,7 +103,7 @@ class TrendingListScreenTest {
                 val exceptionMessage = "Testing Exception"
                 fakeTrendingRepository.setTrendingResultForTest(Result.failure(IOException(exceptionMessage)))
                 performPullToRefresh()
-                checkErrorSnackbarIsDisplayedAndDismissed(exceptionMessage = "Error getting data: $exceptionMessage")
+                checkSnackbarIsDisplayedAndDismissed(message = "Error getting data: $exceptionMessage")
             }
 
             // Reload with only one item for easier testing
@@ -120,6 +119,7 @@ class TrendingListScreenTest {
                 checkGiphyImageItemButtonsLongClickToolTipAreDisplayed()
                 checkOpenInBrowserButton(url = lastGiphyItem.webUrl)
                 checkDownloadImageButton(imageUrl = lastGiphyItem.imageUrl)
+                mainActivityTestRobot.checkSnackbarIsDisplayedAndDismissed(message = composeTestRule.activity.getString(R.string.image_queued_for_download))
                 checkCopyImageLinkButton()
             }
         }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
@@ -104,7 +104,8 @@ fun SearchScreen(
                                 imageUrl = imageUrl,
                                 coroutineScope = coroutineScope,
                                 context = context,
-                                onError = { uiEvent.onShowSnackbar(context.getString(R.string.failed_to_download_file)) },
+                                onSuccess = uiEvent.onQueueDownloadSuccess,
+                                onError = uiEvent.onQueueDownloadFailed,
                             )
                         },
                         onClickToOpen = { url -> context.startBrowserActivity(url = url) },

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchUIEvent.kt
@@ -11,6 +11,8 @@ data class SearchUIEvent(
     val onClearKeyword: () -> Unit,
     val onSearch: () -> Unit,
     val onScrolledToTop: () -> Unit,
+    val onQueueDownloadSuccess: suspend () -> Unit,
+    val onQueueDownloadFailed: suspend () -> Unit,
     val onErrorShown: (errorId: Long) -> Unit,
     val onShowSnackbar: suspend (String) -> Unit,
 )

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreen.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreen.kt
@@ -83,7 +83,8 @@ fun TrendingListScreen(
                             imageUrl = imageUrl,
                             coroutineScope = coroutineScope,
                             context = context,
-                            onError = { uiEvent.onShowSnackbar(context.getString(R.string.failed_to_download_file)) },
+                            onSuccess = uiEvent.onQueueDownloadSuccess,
+                            onError = uiEvent.onQueueDownloadFailed,
                         )
                     },
                     onClickToOpen = { url -> context.startBrowserActivity(url = url) },
@@ -158,6 +159,8 @@ private fun Preview(
                     onErrorShown = {},
                     onShowSnackbar = {},
                     onScrolledToTop = {},
+                    onQueueDownloadFailed = {},
+                    onQueueDownloadSuccess = {},
                 ),
             )
         }
@@ -182,6 +185,8 @@ private fun NoDataPreview() {
                     onErrorShown = {},
                     onShowSnackbar = {},
                     onScrolledToTop = {},
+                    onQueueDownloadFailed = {},
+                    onQueueDownloadSuccess = {},
                 ),
             )
         }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingUIEvent.kt
@@ -8,6 +8,8 @@ package com.rwmobi.giphytrending.ui.destinations.trendinglist
 data class TrendingUIEvent(
     val onRefresh: () -> Unit,
     val onScrolledToTop: () -> Unit,
+    val onQueueDownloadSuccess: suspend () -> Unit,
+    val onQueueDownloadFailed: suspend () -> Unit,
     val onErrorShown: (errorId: Long) -> Unit,
     val onShowSnackbar: suspend (String) -> Unit,
 )

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
@@ -13,12 +13,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.rwmobi.giphytrending.BuildConfig
+import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.ui.destinations.search.SearchScreen
 import com.rwmobi.giphytrending.ui.destinations.search.SearchUIEvent
 import com.rwmobi.giphytrending.ui.destinations.settings.SettingsScreen
@@ -53,6 +55,7 @@ fun AppNavHost(
         composable(route = "trendingList") {
             val viewModel: TrendingViewModel = hiltViewModel()
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            val context = LocalContext.current
 
             LaunchedEffect(lastDoubleTappedNavItem) {
                 val enabled = lastDoubleTappedNavItem?.equals(AppNavItem.TrendingList) ?: false
@@ -73,6 +76,8 @@ fun AppNavHost(
                     onRefresh = { viewModel.refresh() },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.TrendingList) },
+                    onQueueDownloadFailed = { onShowSnackbar(context.getString(R.string.failed_to_download_file)) },
+                    onQueueDownloadSuccess = { onShowSnackbar(context.getString(R.string.image_queued_for_download)) },
                     onShowSnackbar = onShowSnackbar,
                 ),
             )
@@ -85,6 +90,7 @@ fun AppNavHost(
         composable(route = "search") {
             val viewModel: SearchViewModel = hiltViewModel()
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            val context = LocalContext.current
 
             LaunchedEffect(lastDoubleTappedNavItem) {
                 val enabled = lastDoubleTappedNavItem?.equals(AppNavItem.Search) ?: false
@@ -111,6 +117,8 @@ fun AppNavHost(
                     },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Search) },
+                    onQueueDownloadFailed = { onShowSnackbar(context.getString(R.string.failed_to_download_file)) },
+                    onQueueDownloadSuccess = { onShowSnackbar(context.getString(R.string.image_queued_for_download)) },
                     onShowSnackbar = onShowSnackbar,
                 ),
             )

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/utils/DownloadImage.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/utils/DownloadImage.kt
@@ -11,13 +11,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-fun downloadImage(imageUrl: String, coroutineScope: CoroutineScope, context: Context, onError: suspend () -> Unit) {
+fun downloadImage(imageUrl: String, coroutineScope: CoroutineScope, context: Context, onError: suspend () -> Unit, onSuccess: suspend () -> Unit) {
     coroutineScope.launch {
-        val result = withContext(Dispatchers.IO) {
+        val isSuccess = withContext(Dispatchers.IO) {
             context.downloadImageUsingMediaStore(imageUrl)
         }
-        if (!result) {
-            withContext(Dispatchers.Main) {
+        withContext(Dispatchers.Main) {
+            if (isSuccess) {
+                onSuccess()
+            } else {
                 onError()
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,5 +44,6 @@
     <string name="content_description_pull_to_refresh">Pull to refresh</string>
     <string name="content_description_search_bar">Search bar</string>
     <string name="content_description_slider">slider</string>
+    <string name="image_queued_for_download">Image queued for download</string>
 
 </resources>


### PR DESCRIPTION
Originally we only show snackbar message when failed to queue an image for download, now we do the same for a successful attempt, because on some device users may not notice the download has started due to os settings.