### PR TITLE
(#205) filter duplicated snackbar messages

### DIFF
--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
@@ -129,12 +129,7 @@ class SearchViewModel @Inject constructor(
         viewModelScope.launch(dispatcher) {
             userPreferencesRepository.preferenceErrors.collect { preferenceErrors ->
                 Timber.e(preferenceErrors)
-                _uiState.update {
-                    addErrorMessage(
-                        currentUiState = it,
-                        message = preferenceErrors.localizedMessage ?: "Unknown error",
-                    )
-                }
+                updateUIForError(message = preferenceErrors.localizedMessage ?: "Unknown error")
             }
         }
     }
@@ -183,22 +178,19 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun updateUIForError(message: String) {
-        _uiState.update {
-            addErrorMessage(
-                currentUiState = it,
-                message = message,
+        _uiState.update { currentUiState ->
+            val newErrorMessages = if (_uiState.value.errorMessages.any { it.message == message }) {
+                currentUiState.errorMessages
+            } else {
+                currentUiState.errorMessages + ErrorMessage(
+                    id = UUID.randomUUID().mostSignificantBits,
+                    message = message,
+                )
+            }
+            currentUiState.copy(
+                isLoading = false,
+                errorMessages = newErrorMessages,
             )
         }
-    }
-
-    private fun addErrorMessage(currentUiState: SearchUIState, message: String): SearchUIState {
-        val newErrorMessage = ErrorMessage(
-            id = UUID.randomUUID().mostSignificantBits,
-            message = message,
-        )
-        return currentUiState.copy(
-            isLoading = false,
-            errorMessages = currentUiState.errorMessages + newErrorMessage,
-        )
     }
 }

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
@@ -189,6 +189,33 @@ internal class SearchViewModelTest {
     }
 
     @Test
+    fun errorMessages_ShouldAccumulateErrorMessages_OnMultipleFailures() = runTest {
+        val errorMessage1 = "Test error 1"
+        val errorMessage2 = "Test error 2"
+
+        fakeUserPreferencesRepository.emitError(Exception(errorMessage1))
+        fakeUserPreferencesRepository.emitError(Exception(errorMessage2))
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 2
+        uiState.errorMessages[0].message shouldBe errorMessage1
+        uiState.errorMessages[1].message shouldBe errorMessage2
+    }
+
+    @Test
+    fun errorMessages_ShouldNotAccumulateDuplicatedErrorMessages_OnMultipleFailures() = runTest {
+        val errorMessage = "Test error"
+
+        repeat(times = 2) {
+            fakeUserPreferencesRepository.emitError(Exception(errorMessage))
+        }
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 1
+        uiState.errorMessages[0].message shouldBe errorMessage
+    }
+
+    @Test
     fun errorShown_ShouldRemoveErrorMessageFromUIState_WhenCalled() = runTest {
         val errorMessage = "Test error"
         fakeUserPreferencesRepository.emitError(Exception(errorMessage))


### PR DESCRIPTION
Duplicated snackbar messages are now filtered.
Note that on Settings screen we do not actually queue error message, so this applies to trending and search screens only.