### PR TITLE
(#204) Use Results.fold to simply result handling

### DIFF
--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
@@ -164,17 +164,21 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun processTrendingList(repositoryResult: Result<List<GifObject>>) {
-        when (repositoryResult.isFailure) {
-            true -> updateUIForError("Error getting data: ${repositoryResult.exceptionOrNull()?.message}")
-            false -> _uiState.update { currentUiState ->
-                currentUiState.copy(
-                    isLoading = false,
-                    gifObjects = repositoryResult.getOrNull() ?: emptyList(),
-                ).also {
-                    Timber.tag("processTrendingList").v("Processed ${repositoryResult.getOrNull()?.count() ?: 0} entries")
+        repositoryResult.fold(
+            onSuccess = { gifObjects ->
+                _uiState.update { currentUiState ->
+                    currentUiState.copy(
+                        isLoading = false,
+                        gifObjects = gifObjects,
+                    ).also {
+                        Timber.tag("processTrendingList").v("Processed ${gifObjects.count()} entries")
+                    }
                 }
-            }
-        }
+            },
+            onFailure = { exception ->
+                updateUIForError("Error getting data: ${exception.message}")
+            },
+        )
     }
 
     private fun updateUIForError(message: String) {

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModel.kt
@@ -112,17 +112,21 @@ class TrendingViewModel @Inject constructor(
     }
 
     private fun processTrendingList(repositoryResult: Result<List<GifObject>>, isLoadingDone: Boolean) {
-        when (repositoryResult.isFailure) {
-            true -> updateUIForError("Error getting data: ${repositoryResult.exceptionOrNull()?.message}")
-            false -> _uiState.update { currentUiState ->
-                currentUiState.copy(
-                    isLoading = !isLoadingDone,
-                    gifObjects = repositoryResult.getOrNull() ?: emptyList(),
-                ).also {
-                    Timber.tag("processTrendingList").v("Processed ${repositoryResult.getOrNull()?.count() ?: 0} entries, isLoading = ${!isLoadingDone}")
+        repositoryResult.fold(
+            onSuccess = { gifObjects ->
+                _uiState.update { currentUiState ->
+                    currentUiState.copy(
+                        isLoading = !isLoadingDone,
+                        gifObjects = gifObjects,
+                    ).also {
+                        Timber.tag("processTrendingList").v("Processed ${gifObjects.count()} entries, isLoading = ${!isLoadingDone}")
+                    }
                 }
-            }
-        }
+            },
+            onFailure = { exception ->
+                updateUIForError("Error getting data: ${exception.message}")
+            },
+        )
     }
 
     private fun updateUIForError(message: String) {


### PR DESCRIPTION
So as to get rid of the never-exists null results or exceptions.