### PR TITLE
(#258) Provide coil ImageLoader from activity instead of viewmodel

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -267,7 +267,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
 
     implementation(libs.coil)
+    implementation(libs.coil.network.ktor3)
     implementation(libs.coil.gif)
+    implementation(libs.coil.test)
 
     // Ktor as replacement of Retrofit
     implementation(libs.ktor.client.cio)

--- a/app/src/main/java/com/rwmobi/giphytrending/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/MainActivity.kt
@@ -12,11 +12,17 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.ui.components.GiphyTrendingApp
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var imageLoader: ImageLoader
+
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -27,6 +33,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             GiphyTrendingApp(
                 windowSizeClass = calculateWindowSizeClass(this),
+                imageLoader = imageLoader,
             )
         }
     }

--- a/app/src/main/java/com/rwmobi/giphytrending/di/CoilModule.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/di/CoilModule.kt
@@ -6,9 +6,7 @@
 package com.rwmobi.giphytrending.di
 
 import android.content.Context
-import coil.ImageLoader
-import coil.decode.GifDecoder
-import coil.decode.ImageDecoderDecoder
+import coil3.ImageLoader
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,13 +21,13 @@ object CoilModule {
     @Provides
     fun provideCoilImageLoader(@ApplicationContext context: Context): ImageLoader {
         return ImageLoader.Builder(context)
-            .components {
-                if (android.os.Build.VERSION.SDK_INT >= 28) {
-                    add(ImageDecoderDecoder.Factory())
-                } else {
-                    add(GifDecoder.Factory())
-                }
-            }
+//            .components {
+//                if (android.os.Build.VERSION.SDK_INT >= 28) {
+//                    add(ImageDecoderDecoder.Factory())
+//                } else {
+//                    add(GifDecoder.Factory())
+//                }
+//            }
             .build()
     }
 }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/AppMasterNavigationLayout.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/AppMasterNavigationLayout.kt
@@ -31,12 +31,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.ui.navigation.AppNavHost
 import com.rwmobi.giphytrending.ui.navigation.AppNavItem
@@ -69,6 +71,7 @@ fun AppMasterNavigationLayout(
     modifier: Modifier = Modifier,
     windowSizeClass: WindowSizeClass,
     navController: NavHostController,
+    imageLoader: ImageLoader,
     snackbarHostState: SnackbarHostState,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -135,6 +138,7 @@ fun AppMasterNavigationLayout(
                     .padding(paddingValues),
                 isLargeScreen = navigationLayoutType == NavigationLayoutType.NavigationRail,
                 navController = navController,
+                imageLoader = imageLoader,
                 lastDoubleTappedNavItem = lastDoubleTappedNavItem.value,
                 scrollBehavior = scrollBehavior,
                 onShowSnackbar = { errorMessageText ->
@@ -163,6 +167,7 @@ private fun Preview() {
             AppMasterNavigationLayout(
                 modifier = Modifier.fillMaxSize(),
                 windowSizeClass = getPreviewWindowSizeClass(),
+                imageLoader = ImageLoader(LocalContext.current),
                 navController = rememberNavController(),
                 snackbarHostState = remember { SnackbarHostState() },
             )

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItem.kt
@@ -43,9 +43,10 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.ui.previewparameter.GiphyImageItemProvider

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItemCard.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyItemCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.ui.previewparameter.GiphyImageItemProvider
 import com.rwmobi.giphytrending.ui.theme.GiphyTrendingTheme

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyStaggeredGrid.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyStaggeredGrid.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.ui.previewparameter.GiphyImageItemsProvider
 import com.rwmobi.giphytrending.ui.theme.GiphyTrendingTheme

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyTrendingApp.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyTrendingApp.kt
@@ -16,11 +16,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.ui.theme.GiphyTrendingTheme
 
 @Composable
 fun GiphyTrendingApp(
     windowSizeClass: WindowSizeClass,
+    imageLoader: ImageLoader,
 ) {
     val navController = rememberNavController()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -38,6 +40,7 @@ fun GiphyTrendingApp(
                     .imePadding(),
                 windowSizeClass = windowSizeClass,
                 navController = navController,
+                imageLoader = imageLoader,
                 snackbarHostState = snackbarHostState,
             )
         }

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/search/SearchScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.net.toUri
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.ui.components.GiphyStaggeredGrid
 import com.rwmobi.giphytrending.ui.components.NoDataScreen

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreen.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/destinations/trendinglist/TrendingListScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.core.net.toUri
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.ui.components.GiphyStaggeredGrid

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/navigation/AppNavHost.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import coil3.ImageLoader
 import com.rwmobi.giphytrending.BuildConfig
 import com.rwmobi.giphytrending.R
 import com.rwmobi.giphytrending.ui.destinations.search.SearchScreen
@@ -37,6 +38,7 @@ fun AppNavHost(
     modifier: Modifier = Modifier,
     isLargeScreen: Boolean,
     navController: NavHostController,
+    imageLoader: ImageLoader,
     lastDoubleTappedNavItem: AppNavItem?,
     scrollBehavior: TopAppBarScrollBehavior,
     onShowSnackbar: suspend (String) -> Unit,
@@ -70,7 +72,7 @@ fun AppNavHost(
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection),
                 useCardLayout = isLargeScreen,
-                imageLoader = viewModel.getImageLoader(),
+                imageLoader = imageLoader,
                 uiState = uiState,
                 uiEvent = TrendingUIEvent(
                     onRefresh = { viewModel.refresh() },
@@ -105,7 +107,7 @@ fun AppNavHost(
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection),
                 useCardLayout = isLargeScreen,
-                imageLoader = viewModel.getImageLoader(),
+                imageLoader = imageLoader,
                 uiState = uiState,
                 uiEvent = SearchUIEvent(
                     onFetchLastSuccessfulSearch = { viewModel.fetchLastSuccessfulSearch() },

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModel.kt
@@ -7,7 +7,6 @@ package com.rwmobi.giphytrending.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import coil.ImageLoader
 import com.rwmobi.giphytrending.di.DispatcherModule
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.domain.model.Rating
@@ -30,7 +29,6 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val searchRepository: SearchRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val imageLoader: ImageLoader,
     @DispatcherModule.MainDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     // API returns HTTP 414 if query string longer than this
@@ -122,8 +120,6 @@ class SearchViewModel @Inject constructor(
             )
         }
     }
-
-    fun getImageLoader() = imageLoader
 
     private fun collectErrors() {
         viewModelScope.launch(dispatcher) {

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModel.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModel.kt
@@ -7,7 +7,6 @@ package com.rwmobi.giphytrending.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import coil.ImageLoader
 import com.rwmobi.giphytrending.di.DispatcherModule
 import com.rwmobi.giphytrending.domain.model.GifObject
 import com.rwmobi.giphytrending.domain.model.Rating
@@ -30,7 +29,6 @@ import javax.inject.Inject
 class TrendingViewModel @Inject constructor(
     private val trendingRepository: TrendingRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val imageLoader: ImageLoader,
     @DispatcherModule.MainDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<TrendingUIState> = MutableStateFlow(TrendingUIState(isLoading = true))
@@ -75,8 +73,6 @@ class TrendingViewModel @Inject constructor(
             )
         }
     }
-
-    fun getImageLoader() = imageLoader
 
     private fun collectErrors() {
         viewModelScope.launch(dispatcher) {

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/SearchViewModelTest.kt
@@ -5,13 +5,11 @@
 
 package com.rwmobi.giphytrending.ui.viewmodel
 
-import coil.ImageLoader
 import com.rwmobi.giphytrending.data.repository.FakeSearchRepository
 import com.rwmobi.giphytrending.data.repository.FakeUserPreferencesRepository
 import com.rwmobi.giphytrending.domain.model.Rating
 import com.rwmobi.giphytrending.domain.model.UserPreferences
 import com.rwmobi.giphytrending.test.testdata.SampleGifObjectList
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -21,7 +19,6 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -29,17 +26,14 @@ internal class SearchViewModelTest {
     private lateinit var viewModel: SearchViewModel
     private lateinit var fakeSearchRepository: FakeSearchRepository
     private lateinit var fakeUserPreferencesRepository: FakeUserPreferencesRepository
-    private lateinit var mockImageLoader: ImageLoader
 
     @Before
     fun setUp() {
         fakeUserPreferencesRepository = FakeUserPreferencesRepository()
         fakeSearchRepository = FakeSearchRepository()
-        mockImageLoader = mockk(relaxed = true)
         viewModel = SearchViewModel(
             searchRepository = fakeSearchRepository,
             userPreferencesRepository = fakeUserPreferencesRepository,
-            imageLoader = mockImageLoader,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
@@ -156,13 +150,6 @@ internal class SearchViewModelTest {
             assertEquals("Error getting data: $errorMessage", errorMessages.first().message)
             assertFalse(isLoading)
         }
-    }
-
-    @Test
-    fun `returns correct image loader instance when getImageLoader is called`() {
-        val expectedImageLoader = mockImageLoader
-        val imageLoader = viewModel.getImageLoader()
-        assertSame(expectedImageLoader, imageLoader)
     }
 
     @Test

--- a/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/giphytrending/ui/viewmodel/TrendingViewModelTest.kt
@@ -5,13 +5,11 @@
 
 package com.rwmobi.giphytrending.ui.viewmodel
 
-import coil.ImageLoader
 import com.rwmobi.giphytrending.data.repository.FakeTrendingRepository
 import com.rwmobi.giphytrending.data.repository.FakeUserPreferencesRepository
 import com.rwmobi.giphytrending.domain.model.Rating
 import com.rwmobi.giphytrending.domain.model.UserPreferences
 import com.rwmobi.giphytrending.test.testdata.SampleGifObjectList
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -19,7 +17,6 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -28,13 +25,11 @@ internal class TrendingViewModelTest {
     private lateinit var viewModel: TrendingViewModel
     private lateinit var fakeTrendingRepository: FakeTrendingRepository
     private lateinit var fakeUserPreferencesRepository: FakeUserPreferencesRepository
-    private lateinit var mockImageLoader: ImageLoader
 
     private fun setupViewModel() {
         viewModel = TrendingViewModel(
             trendingRepository = fakeTrendingRepository,
             userPreferencesRepository = fakeUserPreferencesRepository,
-            imageLoader = mockImageLoader,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
@@ -43,7 +38,6 @@ internal class TrendingViewModelTest {
     fun setUp() {
         fakeTrendingRepository = FakeTrendingRepository()
         fakeUserPreferencesRepository = FakeUserPreferencesRepository()
-        mockImageLoader = mockk(relaxed = true)
     }
 
     // Test function names reviewed by Gemini for consistency
@@ -129,16 +123,6 @@ internal class TrendingViewModelTest {
         fakeUserPreferencesRepository.emitError(Exception(errorMessage))
 
         assertTrue(viewModel.uiState.value.errorMessages.any { it.message.contains(errorMessage) })
-    }
-
-    @Test
-    fun `returns correct image loader instance`() {
-        setupViewModel()
-        val expectedImageLoader = mockImageLoader
-
-        val imageLoader = viewModel.getImageLoader()
-
-        assertSame(expectedImageLoader, imageLoader)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 activityCompose = "1.10.1"
 agp = "8.11.0"
 benchmarkMacroJunit4 = "1.3.4"
-coil = "2.7.0"
+coil = "3.2.0"
 composeBom = "2025.06.01"
 coroutines = "1.10.2"
 coreKtx = "1.16.0"
@@ -75,8 +75,10 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
-coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
+coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-gif = { group = "io.coil-kt.coil3", name = "coil-gif", version.ref = "coil" }
+coil-network-ktor3 = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
+coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 


### PR DESCRIPTION
After code reviews and deep discussions with AI, we realise it's not the best to supply ImageLoader from Viewmodel - so we change to provide it from Activity.

Also upgraded coil to v3