### PR TITLE
CI: workaround CI providing API key so we also supply keystore

### DIFF
--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -20,6 +20,13 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+
       - name: set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -38,9 +45,11 @@ jobs:
         env:
           CI: 'true'
           GIPHYAPIKEY: ${{ secrets.GIPHYAPIKEY }}
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}  # Workaround due to api key
 
       - name: Gradle Check
         run: ./gradlew check assembleDebug --no-daemon
         env:
           CI: 'true'
           GIPHYAPIKEY: ${{ secrets.GIPHYAPIKEY }}
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}  # Workaround due to api key


### PR DESCRIPTION
We make use of the same CI flag to supply Giphy API Key, but that'd trigger signing config setup
As a workround we simply provide back the keystore path