### PR TITLE
SearchTextField: remember focusRequester

### DIFF
--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/SearchTextField.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/SearchTextField.kt
@@ -56,7 +56,7 @@ fun SearchTextField(
     onSearch: () -> Unit,
 ) {
     val context = LocalContext.current
-    val focusRequester = FocusRequester()
+    val focusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
     var isFocused by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
Code review by Gemini:

**Problem:** 
FocusRequester() is called on every recomposition. While FocusRequester itself might be lightweight, it's good practice to remember objects that should persist across recompositions and don't need to be recreated.

**Suggestion:** 
Wrap FocusRequester() with remember.

**Rationale:** 
Ensures that the same FocusRequester instance is used, preventing potential subtle issues if a new one were created unnecessarily.