### PR TITLE
Migrate code coverage from Kover to JaCoCo

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -33,7 +33,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Gradle build
-        run: ./gradlew :app:buildReleasePreBundle :app:koverXmlReportDebug
+        run: ./gradlew :app:buildReleasePreBundle :app:jacocoTestReportDebug
         env:
           CI: 'true'
           KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
@@ -46,4 +46,5 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: app/build/reports/kover/reportDebug.xml
+          coverage-reports: app/build/reports/jacoco/jacocoTestReportDebug/jacocoTestReportDebug.xml
+

--- a/AGENT.md
+++ b/AGENT.md
@@ -11,7 +11,7 @@
 - **Networking:** Ktor
 - **Persistence:** Room (Database) and DataStore (Preferences)
 - **Image Loading:** Coil (with Ktor and GIF support)
-- **Quality & Performance:** Detekt, Kotlinter, Kover, Macrobenchmark, and Baseline Profiles.
+- **Quality & Performance:** Detekt, Kotlinter, JaCoCo, Macrobenchmark, and Baseline Profiles.
 
 ## Module Structure
 - `app`: Main application module containing core logic and UI.
@@ -48,7 +48,7 @@
 - **Build Release Bundle:** `./gradlew clean bundleRelease`
 - **Lint/Check:** `./gradlew lint detekt kotlinterCheck`
 - **Format Code:** `./gradlew formatKotlin`
-- **Code Coverage:** `./gradlew koverHtmlReport`
+- **Code Coverage:** `./gradlew :app:jacocoTestReportDebug`
 - **Generate Baseline Profile:** `./gradlew generateBaselineProfile`
 
 ## Development Conventions
@@ -62,7 +62,7 @@ The project strictly follows Clean Architecture principles with a focus on an **
 - **Unit Tests:** Located in `src/test`. Focus on ViewModels and Domain logic.
 - **Test Fixtures:** Manual fakes for repositories are provided in `src/testFixtures` to ensure reliable and fast unit tests without excessive mocking.
 - **UI Tests:** Located in `src/androidTest`. Uses Compose UI testing and Hilt for dependency injection in tests.
-- **Code Coverage:** Managed by Kover.
+- **Code Coverage:** Managed by JaCoCo.
 
 ### Coding Style
 - Follows Kotlin coding standards enforced by **Kotlinter** and **Detekt**.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ now [logged as issues](https://github.com/ryanw-mobile/giphy-trending/issues?q=i
 * [Kotlin Android Plugin](https://kotlinlang.org/docs/gradle.html) - JetBrains - Plugin for Kotlin Android support
 * [Compose Compiler Plugin](https://developer.android.com/jetpack/compose) - JetBrains - Compiler plugin for Jetpack Compose
 * [Hilt Android Plugin](https://dagger.dev/hilt/gradle-setup.html) - Google - Plugin for Hilt dependency injection
-* [Kover Plugin](https://github.com/Kotlin/kotlinx-kover) - JetBrains - Code coverage tool for Kotlin
+* [JaCoCo Plugin](https://github.com/jacoco/jacoco) - JaCoCo - Code coverage tool for Java and Kotlin
 * [KSP Plugin](https://github.com/google/ksp) - Google - Kotlin Symbol Processing API
 * [Android Test Plugin](https://developer.android.com/studio/test) - Google - Plugin for setting up Android test modules
 * [Baseline Profile Plugin](https://developer.android.com/topic/performance/baselineprofiles) - AndroidX - Plugin for generating performance profiles

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.ManagedVirtualDevice
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.FileInputStream
 import java.io.InputStreamReader
 import java.text.SimpleDateFormat
@@ -14,13 +15,17 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.hiltAndroidPlugin)
-    alias(libs.plugins.kotlinxKover)
+    alias(libs.plugins.jacoco)
     alias(libs.plugins.devtoolsKsp)
     alias(libs.plugins.baselineprofile)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.serialization)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlinter)
+}
+
+jacoco {
+    toolVersion = libs.versions.jacoco.get()
 }
 
 // Configuration
@@ -216,45 +221,71 @@ tasks {
 
 detekt { parallel = true }
 
-kover {
-    useJacoco()
-    reports.filters.excludes {
-        packages(
-            "$productNamespace.ui.*",
-            "$productNamespace.di*",
-            "$productNamespace.data.repository.demodata*",
-            "$productNamespace.ui.components",
-            "$productNamespace.ui.destinations",
-            "$productNamespace.ui.navigation",
-            "$productNamespace.ui.previewparameter",
-            "$productNamespace.ui.theme",
-            "$productNamespace.ui.utils",
-        )
+tasks.register<JacocoReport>("jacocoTestReportDebug") {
+    dependsOn("testDebugUnitTest")
 
-        classes(
-            "dagger.hilt.internal.aggregatedroot.codegen.*",
-            "hilt_aggregated_deps.*",
-            "$productNamespace.*.Hilt_*",
-            "$productNamespace.*.*_Factory*",
-            "$productNamespace.*.*_HiltModules*",
-            "$productNamespace.*.*Module_*",
-            "$productNamespace.*.*MembersInjector*",
-            "$productNamespace.*.*_Impl*",
-            "$productNamespace.ComposableSingletons*",
-            "$productNamespace.BuildConfig*",
-            "$productNamespace.*.Fake*",
-            "$productNamespace.*.previewparameter*",
-            "$productNamespace.app.ComposableSingletons*",
-            "$productNamespace.GiphyApplication*",
-            "*Fragment",
-            "*Fragment\$*",
-            "*Activity",
-            "*Activity\$*",
-            "*.databinding.*",
-            "*.BuildConfig",
-            "*.DebugUtil",
-        )
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports for the debug build."
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
     }
+
+    val fileFilter = listOf(
+        "**/R.class",
+        "**/R\$*.class",
+        "**/BuildConfig.*",
+        "**/Manifest*.*",
+        "**/*Test*.*",
+        "android/**/*.*",
+        "**/*\$ViewInjector*.*",
+        "**/*\$ViewBinder*.*",
+        "**/Lambda\$*.class",
+        "**/Lambda.class",
+        "**/*Lambda.class",
+        "**/*Lambda*.class",
+        "**/*_MembersInjector.class",
+        "**/Dagger*Component*.*",
+        "**/*Module_*Factory.class",
+        "**/*_Factory*.*",
+        "**/*_Provide*Factory*.*",
+        "**/*Extensions*.*",
+        "**/*\$Result.*",
+        "**/*\$Result\$*.*",
+        "**/ui/**/*.*",
+        "**/di/**/*.*",
+        "**/data/repository/demodata/**/*.*",
+        "**/ui/components/**/*.*",
+        "**/ui/destinations/**/*.*",
+        "**/ui/navigation/**/*.*",
+        "**/ui/previewparameter/**/*.*",
+        "**/ui/theme/**/*.*",
+        "**/ui/utils/**/*.*",
+        "**/dagger/hilt/internal/aggregatedroot/codegen/**/*.*",
+        "**/hilt_aggregated_deps/**/*.*",
+        "**/*Hilt_*.*",
+        "**/*_HiltModules*.*",
+        "**/*Module_*.*",
+        "**/*_Impl*.*",
+        "**/ComposableSingletons*.*",
+        "**/Fake*.*",
+        "**/GiphyApplication*.*",
+        "**/*Fragment*.*",
+        "**/*Activity*.*",
+        "**/databinding/**/*.*",
+        "**/DebugUtil*.*",
+    )
+
+    val debugTree = fileTree("${project.layout.buildDirectory.get()}/intermediates/classes/debug/transformDebugClassesWithAsm/dirs") {
+        exclude(fileFilter)
+    }
+
+    sourceDirectories.setFrom(files("src/main/java", "src/main/kotlin"))
+    classDirectories.setFrom(files(debugTree))
+    executionData.setFrom(fileTree(project.layout.buildDirectory.get()) {
+        include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+    })
 }
 
 // Gradle Build Utilities - Revision 2026.01.22.01
@@ -347,6 +378,7 @@ private fun ApplicationExtension.setupSigningAndBuildTypes() {
             applicationIdSuffix = ".debug"
             isMinifyEnabled = false
             isDebuggable = true
+            enableUnitTestCoverage = true
         }
 
         getByName("release") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.hiltAndroidPlugin) apply false
     alias(libs.plugins.devtoolsKsp) apply false
-    alias(libs.plugins.kotlinxKover) apply false
     alias(libs.plugins.androidTest) apply false
     alias(libs.plugins.baselineprofile) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinxCoroutinesTest = "1.10.2"
 junit = "4.13.2"
 kotlin = "2.3.10"
 kotlinxDatetime = "0.7.1-0.6.x-compat"
-kover = "0.9.7"
+jacoco = "0.8.12"
 ktor = "3.4.1"
 leakcanary = "2.14"
 legacySupportV4 = "1.0.0"
@@ -112,8 +112,8 @@ ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref =
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hiltAndroidPlugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlinxKover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 devtoolsKsp = { id = "com.google.devtools.ksp", version.ref = "devtoolsksp" }
+jacoco = { id = "org.gradle.jacoco" }
 androidTest = { id = "com.android.test", version.ref = "agp" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Description
Migrated the code coverage engine from Kotlinx Kover to the native JaCoCo Gradle plugin for CI/CD reporting to Codacy. This alignment with industry standards reduces fragility and ensures consistent JaCoCo-native reporting across the project.

### Key Changes
- **Dependency Management**: Removed Kover from  and added JaCoCo version `0.8.12`.
- **Plugin Application**:
  - Removed Kover plugin from root `build.gradle.kts`.
  - Applied `jacoco` plugin in `app/build.gradle.kts`.
- **Task Implementation**:
  - Registered `jacocoTestReportDebug` task with comprehensive exclusion filters (UI, Dagger/Hilt, BuildConfig, etc.).
  - Configured class directories to use modern AGP intermediate paths (`transformDebugClassesWithAsm`).
  - Enabled `enableUnitTestCoverage` in the debug build type.
- **CI/CD Integration**:
  - Updated GitHub Actions (`main_build.yml`) to run `./gradlew :app:jacocoTestReportDebug`.
  - Updated Codacy coverage reporter to point to the new JaCoCo XML report path.
- **Documentation**: Updated `AGENT.md` and `README.md` with new coverage commands and tool details.

### Verification (Mandatory)
- **Local Execution**: Ran `./gradlew :app:jacocoTestReportDebug` successfully.
- **Data Validation**: Verified non-zero coverage in `app/build/reports/jacoco/jacocoTestReportDebug/jacocoTestReportDebug.xml`.
- **Consistency**: Confirmed exclusion filters are correctly omitting 'noise' (UI, DI packages).