### PR TITLE
Fix edge-to-edge status and navigation bar rendering (#296)

### DIFF
--- a/app/src/main/java/com/rwmobi/giphytrending/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/MainActivity.kt
@@ -28,9 +28,9 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
 
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         setContent {
-            enableEdgeToEdge()
             GiphyTrendingApp(
                 adaptiveInfo = currentWindowAdaptiveInfo(),
                 imageLoader = imageLoader,

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/AppMasterNavigationLayout.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/AppMasterNavigationLayout.kt
@@ -6,6 +6,7 @@
 package com.rwmobi.giphytrending.ui.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -96,6 +97,7 @@ fun AppMasterNavigationLayout(
         },
     ) {
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     modifier = Modifier.wrapContentHeight(),

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyTrendingApp.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/components/GiphyTrendingApp.kt
@@ -7,7 +7,6 @@ package com.rwmobi.giphytrending.ui.components
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
@@ -29,7 +28,6 @@ fun GiphyTrendingApp(
     GiphyTrendingTheme {
         Surface(
             modifier = Modifier
-                .safeDrawingPadding()
                 .fillMaxSize(),
             color = GiphyTrendingTheme.colorScheme.background,
         ) {

--- a/app/src/main/java/com/rwmobi/giphytrending/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rwmobi/giphytrending/ui/theme/Theme.kt
@@ -5,7 +5,6 @@
 
 package com.rwmobi.giphytrending.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
@@ -18,16 +17,12 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
-import androidx.core.view.WindowCompat
 
 private val LightColors = lightColorScheme(
     primary = md_theme_light_primary,
@@ -114,15 +109,6 @@ fun GiphyTrendingTheme(
 
         else -> LightColors
     }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
-
     ProvideDimens(dimensions = dimension) {
         ProvideColorScheme(colorScheme = colorScheme) {
             MaterialTheme(


### PR DESCRIPTION
## Summary
- Move `enableEdgeToEdge()` before `setContent` in `MainActivity` — it was incorrectly placed inside a `@Composable` lambda, causing it to fire on every recomposition
- Remove manual `statusBarColor` and `isAppearanceLightStatusBars` `SideEffect` from `Theme.kt` — the status bar colour was overriding `enableEdgeToEdge()`, and the light/dark icon appearance was inverted (dark icons on dark background); `enableEdgeToEdge()` handles both automatically
- Remove `safeDrawingPadding()` from the root `Surface` in `GiphyTrendingApp` — this was shrinking the Surface away from the screen edges, exposing the white Activity window background behind the transparent status bar; the Surface now extends edge-to-edge so the app background colour shows through
- Add `contentWindowInsets = WindowInsets(0, 0, 0, 0)` to `Scaffold` to prevent double-inset padding — status bar inset is owned by `TopAppBar`, nav bar inset is owned by `NavigationSuiteScaffold`, and IME inset is handled by the outer `imePadding()` modifier

## Test plan
- [ ] Portrait: status bar shows app background colour with correct icon contrast (light theme → dark icons, dark theme → light icons)
- [ ] Portrait: navigation bar background matches the bottom navigation bar colour
- [ ] Landscape / tablet: rotate device to show navigation rail — status bar and side insets look correct with no white gaps
- [ ] Dynamic colour (Android 12+): verify status bar blends with dynamic background
- [ ] Keyboard: open search screen and verify content shifts up correctly without double IME padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)